### PR TITLE
Applied Radium to all decorators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ build/Release
 node_modules
 
 lib/
+/jsconfig.json

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 React Tree View Component. Data-Driven, Fast, Efficient and Customisable.
 
-[![Click here to lend your support to: React-Treebeard and make a donation at pledgie.com !](https://pledgie.com/campaigns/30722.png?skin_name=chrome)](https://pledgie.com/campaigns/30722)
-
 ### Install
 
 ```

--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
   "dependencies": {
     "babel-runtime": "^5.8.29",
     "deep-equal": "^1.0.1",
-    "radium": "^0.16.6",
+    "radium": "^0.17.1",
+    "react-passthrough": "^0.1.0",
     "react-utils": "alexcurtis/react-utils",
     "shallowequal": "^0.2.2",
     "velocity-react": "^1.1.2"

--- a/src/components/decorators.js
+++ b/src/components/decorators.js
@@ -4,19 +4,19 @@ import React from 'react';
 import Radium from 'radium';
 import {VelocityComponent} from 'velocity-react';
 
-const Loading = (props) => {
+const Loading = Radium((props) => {
     return (
         <div style={props.style}>
             loading...
         </div>
     );
-};
+});
 
 Loading.propTypes = {
     style: React.PropTypes.object
 };
 
-const Toggle = (props) => {
+const Toggle = Radium((props) => {
     const style = props.style;
     const height = style.height;
     const width = style.width;
@@ -34,13 +34,13 @@ const Toggle = (props) => {
             </div>
         </div>
     );
-};
+});
 
 Toggle.propTypes = {
     style: React.PropTypes.object
 };
 
-const Header = (props) => {
+const Header = Radium((props) => {
     const style = props.style;
     return (
         <div style={style.base}>
@@ -49,7 +49,7 @@ const Header = (props) => {
             </div>
         </div>
     );
-};
+});
 
 Header.propTypes = {
     style: React.PropTypes.object,

--- a/src/components/decorators.js
+++ b/src/components/decorators.js
@@ -1,10 +1,11 @@
 'use strict';
 
 import React from 'react';
-import Radium from 'radium';
+import radium from 'radium';
 import {VelocityComponent} from 'velocity-react';
+import passThrough from 'react-passthrough';
 
-const Loading = Radium((props) => {
+const Loading = radium((props) => {
     return (
         <div style={props.style}>
             loading...
@@ -16,7 +17,7 @@ Loading.propTypes = {
     style: React.PropTypes.object
 };
 
-const Toggle = Radium((props) => {
+const Toggle = radium((props) => {
     const style = props.style;
     const height = style.height;
     const width = style.width;
@@ -40,7 +41,7 @@ Toggle.propTypes = {
     style: React.PropTypes.object
 };
 
-const Header = Radium((props) => {
+const Header = radium((props) => {
     const style = props.style;
     return (
         <div style={style.base}>
@@ -56,7 +57,7 @@ Header.propTypes = {
     node: React.PropTypes.object.isRequired
 };
 
-@Radium
+@radium
 class Container extends React.Component {
     constructor(props){
         super(props);
@@ -70,6 +71,7 @@ class Container extends React.Component {
                 style={style.container}>
                 { !terminal ? this.renderToggle() : null }
                 <decorators.Header
+                    {...this.passthrough()}
                     node={node}
                     style={style.header}
                 />
@@ -89,7 +91,7 @@ class Container extends React.Component {
     }
     renderToggleDecorator(){
         const {style, decorators} = this.props;
-        return (<decorators.Toggle style={style.toggle}/>);
+        return (<decorators.Toggle {...this.passthrough()} style={style.toggle}/>);
     }
 }
 
@@ -104,6 +106,8 @@ Container.propTypes = {
     ]).isRequired,
     node: React.PropTypes.object.isRequired
 };
+
+passThrough({omit: ['children', 'form']})(Container);
 
 export default {
     Loading,

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -3,6 +3,7 @@
 import React from 'react';
 import shallowEqual from 'shallowequal';
 import deepEqual from 'deep-equal';
+import passThrough from 'react-passthrough';
 
 class NodeHeader extends React.Component {
     constructor(props){
@@ -27,6 +28,7 @@ class NodeHeader extends React.Component {
         const headerStyles = Object.assign({ container }, this.props.style);
         return (
             <decorators.Container
+                {...this.passthrough()}
                 style={headerStyles}
                 decorators={decorators}
                 terminal={terminal}
@@ -48,5 +50,7 @@ NodeHeader.propTypes = {
     node: React.PropTypes.object.isRequired,
     onClick: React.PropTypes.func
 };
+
+passThrough({omit: ['children', 'form']})(NodeHeader);
 
 export default NodeHeader;

--- a/src/components/node.js
+++ b/src/components/node.js
@@ -3,6 +3,7 @@
 import React from 'react';
 import rutils from 'react-utils';
 import {VelocityTransitionGroup} from 'velocity-react';
+import passThrough from 'react-passthrough';
 
 import NodeHeader from './header';
 
@@ -56,6 +57,7 @@ class TreeNode extends React.Component {
     renderHeader(decorators, animations){
         return (
             <NodeHeader
+                {...this.passthrough()}
                 decorators={decorators}
                 animations={animations}
                 style={this.props.style}
@@ -70,6 +72,7 @@ class TreeNode extends React.Component {
             <ul style={this.props.style.subtree} ref="subtree">
                 {rutils.children.map(this.props.node.children, (child, index) =>
                     <TreeNode
+                        {...this.passthrough()}
                         {...this._eventBubbles()}
                         key={child.id || index}
                         node={child}
@@ -85,7 +88,7 @@ class TreeNode extends React.Component {
         return (
             <ul style={this.props.style.subtree}>
                 <li>
-                    <decorators.Loading style={this.props.style.loading}/>
+                    <decorators.Loading {...this.passthrough()} style={this.props.style.loading}/>
                 </li>
             </ul>
         );
@@ -105,5 +108,7 @@ TreeNode.propTypes = {
     ]).isRequired,
     onToggle: React.PropTypes.func
 };
+
+passThrough({omit: ['children', 'form']})(TreeNode);
 
 export default TreeNode;

--- a/src/components/treebeard.js
+++ b/src/components/treebeard.js
@@ -6,6 +6,7 @@ import TreeNode from './node';
 import defaultDecorators from './decorators';
 import defaultTheme from '../themes/default';
 import defaultAnimations from '../themes/animations';
+import passThrough from 'react-passthrough';
 
 class TreeBeard extends React.Component {
     constructor(props){
@@ -15,10 +16,12 @@ class TreeBeard extends React.Component {
         let data = this.props.data;
         // Support Multiple Root Nodes. Its not formally a tree, but its a use-case.
         if(!Array.isArray(data)){ data = [data]; }
+        const self = this;
         return (
             <ul style={this.props.style.tree.base} ref="treeBase">
                 {data.map((node, index) =>
                     <TreeNode
+                        {...self.passthrough()}
                         key={node.id || index}
                         node={node}
                         onToggle={this.props.onToggle}
@@ -51,5 +54,7 @@ TreeBeard.defaultProps = {
     animations: defaultAnimations,
     decorators: defaultDecorators
 };
+
+passThrough({omit: ['children', 'form', 'data']})(TreeBeard);
 
 export default TreeBeard;


### PR DESCRIPTION
Alternatively, if developers are using custom decorators, they could/would do the same to their custom decorator definition. May be worth a note in the readme? Thanks for the great component!

```
decorators.Header = Radium((props) => {
  const styles = {
    base: {},
    ext: {}
  };
  return <div style={[styles.base, styles.ext]}>Custom Header</div>;
});
```
