### PR TITLE
fix background width error when the depth of tree is too long

### DIFF
--- a/src/themes/default.js
+++ b/src/themes/default.js
@@ -5,6 +5,8 @@ export default {
         base: {
             listStyle: 'none',
             backgroundColor: '#21252B',
+            minWidth: '100%',
+            float: 'left',
             margin: 0,
             padding: 0,
             color: '#9DA5AB',
@@ -13,7 +15,8 @@ export default {
         },
         node: {
             base: {
-                position: 'relative'
+                position: 'relative',
+                whiteSpace: 'nowrap'
             },
             link: {
                 cursor: 'pointer',


### PR DESCRIPTION
fix background width error when the depth of tree is too long;
forbid word wrap