### PR TITLE
Cleanup npm Tarball from Unnecessary Files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,14 @@ _site
 coverage
 node_modules
 npm-debug.log
+.eslintrc
+.babelrc
+.npmignore
+.idea
+example/
+
+.travis.yml
+Gulpfile.js
+karma.conf.js
+webpack.config.test.js
+test/


### PR DESCRIPTION
Hello! Thanks for a nice React component.

There are a lot of unnecessary files uploaded to NPM registry, check this:

![2017-10-22_211756](https://user-images.githubusercontent.com/4989256/31864915-7fa29f70-b76e-11e7-81b3-e2c355120b22.png)

This pull request adds some of them to `.npmignore` file and hence saves a bit of worldwide traffic 😄

Also this fixes Webpack trying to pick up `.babelrc` file and finding plugins that are not installed in the system.

`src` folder may also be excluded (as you build to `lib`), but I leave it up to your preference.