### PR TITLE
Fixed container array issue in header.js 

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -29,7 +29,7 @@ class NodeHeader extends React.Component {
         const {animations, decorators, node, onClick, style} = this.props;
         const {active, children} = node;
         const terminal = !children;
-        const container = [style.link, active ? style.activeLink : null];
+        const container = (active && style.activeLink) ? Object.assign({}, style.link, style.activeLink)  : style.link;
         const headerStyles = Object.assign({container}, style);
 
         return (


### PR DESCRIPTION
Firefox was raising a TypeError when react attempted to apply an array of styles taken from the container value into a header.  The fix simply made it a merged single object as opposed to an array of 2 objects, one being null if not active.