### PR TITLE
fix a bug that activeLink does not work

### DIFF
--- a/src/components/decorators.js
+++ b/src/components/decorators.js
@@ -61,7 +61,7 @@ class Container extends React.Component {
         return (
             <div onClick={onClick}
                  ref={ref => this.clickableRef = ref}
-                 style={style.container}>
+                 style={Object.assign({}, ...style.container)}>
                 {!terminal ? this.renderToggle() : null}
 
                 <decorators.Header node={node}


### PR DESCRIPTION
This is because React's style prop does not support an array.

